### PR TITLE
Improve support for quoted values

### DIFF
--- a/default.json
+++ b/default.json
@@ -78,8 +78,10 @@
     {
       "fileMatch": [".+"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s(?:ENV|ARG) .+?_(v|V)(ersion|ERSION|alue|ALUE)\\s*[:=]\\s*[\"']?\\s*(?<currentValue>[^\"'\\s]+)\\s*[\"']?\\s",
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*_?(v|V)(ersion|ERSION|alue|ALUE)\\s*[:=]\\s*[\"']?\\s*(?<currentValue>[^\"'\\s]+)\\s*[\"']?\\s"
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s(?:ENV|ARG) .+?_(v|V)(ersion|ERSION|alue|ALUE)\\s*[:=]\\s*[\"']\\s*(?<currentValue>[^\"'\\r\\n]+?)\\s*[\"']",
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s(?:ENV|ARG) .+?_(v|V)(ersion|ERSION|alue|ALUE)\\s*[:=]\\s*(?<currentValue>[^\"'\\s]+)",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*_?(v|V)(ersion|ERSION|alue|ALUE)\\s*[:=]\\s*[\"']\\s*(?<currentValue>[^\"'\\r\\n]+?)\\s*[\"']",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*_?(v|V)(ersion|ERSION|alue|ALUE)\\s*[:=]\\s*(?<currentValue>[^\"'\\s]+)"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }


### PR DESCRIPTION
This pull request updates the regular expressions used for matching version annotations in the `default.json` configuration file. The changes refine and expand the patterns to improve accuracy and flexibility when detecting version strings, especially those enclosed in quotes.

Pattern matching improvements:

* Updated the first two regular expressions to require version values to be enclosed in quotes and to match non-line-breaking characters, improving accuracy when extracting quoted version strings.
* Added two new regular expressions to handle both quoted and unquoted version values, increasing flexibility and robustness in detecting various annotation styles.